### PR TITLE
Update nav bar content to flex layout space-around

### DIFF
--- a/src/components/Layout.module.css
+++ b/src/components/Layout.module.css
@@ -51,7 +51,7 @@ header img {
 /* nav styles */
 .navContent {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-around;
 }
 .navContent a {
   color: white;


### PR DESCRIPTION
I only updated the nav bar layout, the logo should stay in its place instead of being in the center.
